### PR TITLE
Race condition when using the extension in non-synchronous workers

### DIFF
--- a/flask_weaviate/__init__.py
+++ b/flask_weaviate/__init__.py
@@ -308,6 +308,10 @@ class FlaskWeaviate(object):
         return app
 
     @property
+    def _client(self) -> Optional[WeaviateClient]:
+        return g.get('weaviate_client', None)
+
+    @property
     def client(self) -> WeaviateClient:
         """
         Lazily connect the WeaviateClient when it's first accessed.
@@ -315,7 +319,7 @@ class FlaskWeaviate(object):
         :return: The WeaviateClient instance.
         :rtype: WeaviateClient
         """
-        if 'weaviate_client' not in g:
+        if g.get('weaviate_client', None) is None:
             g.weaviate_client = WeaviateClient(**self.weaviate_config)
         if g.weaviate_client.is_connected() is False:
             try:

--- a/flask_weaviate/__init__.py
+++ b/flask_weaviate/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from typing import Dict, Optional, Union
 
-from flask import Flask, current_app, has_app_context
+from flask import Flask, current_app, has_app_context, g
 from weaviate import WeaviateClient
 from weaviate.auth import (
     AuthApiKey,
@@ -181,7 +181,6 @@ class FlaskWeaviate(object):
         additional_config: Optional[AdditionalConfig] = None,
         skip_init_checks: bool = False,
     ):
-        self._client = None
         # Connection check. first check setup with params,
         # then connection params else embedded is set as standard
         if any(
@@ -288,7 +287,6 @@ class FlaskWeaviate(object):
             self.additional_config = app.config.get("WEAVIATE_ADDITIONAL_CONFIG")
         if app.config.get("WEAVIATE_SKIP_INIT_CHECKS") is not None:
             self.skip_init_checks = app.config.get("WEAVIATE_SKIP_INIT_CHECKS")
-        self._client = WeaviateClient(**self.weaviate_config)
 
         # Store the WeaviateClient instance in the app context
         if not hasattr(app, "extensions"):
@@ -296,15 +294,16 @@ class FlaskWeaviate(object):
         app.extensions["weaviate"] = self
 
         @app.teardown_appcontext
-        def close_connection(responese_or_exception):
+        def close_connection(response_or_exception):
             """
             Disconnect the Weaviate client during app context teardown.
 
-            :param responese_or_exception:
+            :param response_or_exception:
             """
-            if hasattr(self, "_client"):
-                self._client.close()
-            return responese_or_exception
+            weaviate_client = g.pop('weaviate_client', None)
+            if weaviate_client is not None:
+                weaviate_client.close()
+            return response_or_exception
 
         return app
 
@@ -316,14 +315,14 @@ class FlaskWeaviate(object):
         :return: The WeaviateClient instance.
         :rtype: WeaviateClient
         """
-        if not hasattr(self, "_client") or self._client is None:
-            self._client = WeaviateClient(**self.weaviate_config)
-        if self._client.is_connected() is False:
+        if 'weaviate_client' not in g:
+            g.weaviate_client = WeaviateClient(**self.weaviate_config)
+        if g.weaviate_client.is_connected() is False:
             try:
-                self._client.connect()
+                g.weaviate_client.connect()
             except WeaviateStartUpError as e:
                 raise Exception("Failed to connect to Weaviate server") from e
-        return self._client
+        return g.weaviate_client
 
     @property
     def weaviate_config(self):

--- a/tests/import/test_a_imports.py
+++ b/tests/import/test_a_imports.py
@@ -4,7 +4,7 @@ import pytest
 def test_import_failure_flask(monkeypatch):
     import sys
     with monkeypatch.context() as m:
-        monkeypatch.setitem(sys.modules, "flask", None)
+        m.setitem(sys.modules, "flask", None)
 
         with pytest.raises(ImportError) as e:
             from flask_weaviate import FlaskWeaviate
@@ -15,7 +15,7 @@ def test_import_failure_flask(monkeypatch):
 def test_import_failure_weaviate(monkeypatch):
     import sys
     with monkeypatch.context() as m:
-        monkeypatch.setitem(sys.modules, "weaviate", None)
+        m.setitem(sys.modules, "weaviate", None)
 
         with pytest.raises(ImportError) as e:
             from flask_weaviate import FlaskWeaviate


### PR DESCRIPTION
When using the extension with greenlet workers (e.g. `gunicorn -k gevent`), the weaviate client was shared by all concurrent requests, which lead to conflicts and early disconnections on ongoing queries.

This pull request adds support for concurrent requests by creating a new client per request, stored in the app context. The client is closed on app context teardown. We assume that the extension will always be run in the presence of an active app context, dropping support for a global client.

The tests have been adjusted accordingly.